### PR TITLE
chore: 更新kit依赖

### DIFF
--- a/app.json
+++ b/app.json
@@ -168,8 +168,8 @@
     "downloadFile": 60000
   },
   "dependencies": {
-    "BaseKit": "2.0.3",
-    "MiniKit": "2.0.3",
-    "TYKit": "2.0.4"
+    "base-kit": "2.1.2",
+    "mini-kit": "2.3.0",
+    "ty-kit": "2.0.7"
   }
 }


### PR DESCRIPTION
chore: 更新kit依赖，对外起始版本依赖。
  1. minikit 2.3.0
  2. basekit 2.1.2
  3. tykit 2.0.7
  4. devicekit 2.1.6